### PR TITLE
Feature/issue 25

### DIFF
--- a/Assets/LDtkUnity/Editor/CustomEditor/SectionDrawers/LDtkSectionMain.cs
+++ b/Assets/LDtkUnity/Editor/CustomEditor/SectionDrawers/LDtkSectionMain.cs
@@ -52,7 +52,12 @@ namespace LDtkUnity.Editor
             text = "Create Background Color",
             tooltip = "Creates a flat background for each level, based on the level's background color."
         };
-        
+        private static readonly GUIContent AllowHDSprites = new GUIContent
+        {
+            text = "Allow HD Sprites",
+            tooltip = "Allow using HD Sprites if available."
+        };
+
         protected override string GuiText => "Main";
         protected override string GuiTooltip => "This is the importer menu.\n" +
                                                 "Configure all of your custom settings here.";
@@ -111,6 +116,8 @@ namespace LDtkUnity.Editor
             }
             
             DrawField(CreateBackgroundColor, LDtkProjectImporter.CREATE_BACKGROUND_COLOR);
+
+            DrawField(AllowHDSprites, LDtkProjectImporter.ALLOW_HD_SPRITES);
         }
 
         private SpriteAtlas DrawAtlasFieldAndButton()

--- a/Assets/LDtkUnity/Editor/ScriptedImporter/LDtkProjectImporter.cs
+++ b/Assets/LDtkUnity/Editor/ScriptedImporter/LDtkProjectImporter.cs
@@ -32,7 +32,8 @@ namespace LDtkUnity.Editor
         public const string INTGRID_VISIBLE = nameof(_intGridValueColorsVisible);
         public const string USE_COMPOSITE_COLLIDER = nameof(_useCompositeCollider);
         public const string CREATE_BACKGROUND_COLOR = nameof(_createBackgroundColor);
-        
+        public const string ALLOW_HD_SPRITES = nameof(_allowHDSprites);
+
         public const string INTGRID = nameof(_intGridValues);
         public const string ENTITIES = nameof(_entities);
         
@@ -53,6 +54,7 @@ namespace LDtkUnity.Editor
         [SerializeField] private bool _intGridValueColorsVisible = false;
         [SerializeField] private bool _useCompositeCollider = true;
         [SerializeField] private bool _createBackgroundColor = true;
+        [SerializeField] private bool _allowHDSprites = false;
         
         [SerializeField] private LDtkAssetIntGridValue[] _intGridValues = Array.Empty<LDtkAssetIntGridValue>();
         
@@ -71,6 +73,7 @@ namespace LDtkUnity.Editor
         public GameObject CustomLevelPrefab => _customLevelPrefab;
         public bool UseCompositeCollider => _useCompositeCollider;
         public bool CreateBackgroundColor => _createBackgroundColor;
+        public bool AllowHDSprites => _allowHDSprites;
         public string AssetName => Path.GetFileNameWithoutExtension(assetPath);
         
         private LDtkArtifactAssets _artifacts;

--- a/Assets/LDtkUnity/Editor/Utility/RelativeGetter/LDtkRelativeGetter.cs
+++ b/Assets/LDtkUnity/Editor/Utility/RelativeGetter/LDtkRelativeGetter.cs
@@ -24,7 +24,12 @@ namespace LDtkUnity.Editor
             return GetRelativeAsset(def, assetPath);
         }*/
 
-        public TAsset GetRelativeAsset(TData def, string relativeTo)
+        public virtual T GetRelativeSubAsset<T>(TData def, string relativeTo) where T : Object
+        {
+            return GetAssetRelativeToAssetPath<T>(relativeTo, GetRelPath(def));
+        }
+
+        public virtual TAsset GetRelativeAsset(TData def, string relativeTo)
         {
             return GetAssetRelativeToAssetPath<TAsset>(relativeTo, GetRelPath(def));
         }
@@ -53,7 +58,7 @@ namespace LDtkUnity.Editor
             return assetsPath;
         }
 
-        private T GetAssetRelativeToAssetPath<T>(string assetPath, string relPath) where T : Object
+        protected T GetAssetRelativeToAssetPath<T>(string assetPath, string relPath) where T : Object
         {
             Profiler.BeginSample("GetAssetRelativeToAssetPath");
             string fullPath = GetPathRelativeToPath(assetPath, relPath);
@@ -79,7 +84,7 @@ namespace LDtkUnity.Editor
             return null;
         }
 
-        private static void LogFailIsAssetRelativeToAssetPathExists(string assetsPath)
+        protected static void LogFailIsAssetRelativeToAssetPathExists(string assetsPath)
         {
             //if it was an aseprite path
             if (string.IsNullOrEmpty(assetsPath))

--- a/Assets/LDtkUnity/Editor/Utility/RelativeGetter/LDtkRelativeGetterTilesetTextureHD.cs
+++ b/Assets/LDtkUnity/Editor/Utility/RelativeGetter/LDtkRelativeGetterTilesetTextureHD.cs
@@ -1,0 +1,88 @@
+﻿using System.IO;
+using UnityEngine;
+using UnityEditor;
+
+namespace LDtkUnity.Editor
+{
+    internal class LDtkRelativeGetterTilesetTextureHD : LDtkRelativeGetterTilesetTexture
+    {
+        
+        public override Texture2D GetRelativeAsset(TilesetDefinition def, string relativeTo)
+        {            
+            return GetMainAsset<Texture2D>(GetRelPathHD(def, relativeTo));
+        }
+
+        public override T GetRelativeSubAsset<T>(TilesetDefinition def, string relativeTo)
+        {
+            var realPath = GetRelPathHD(def, relativeTo);
+            return GetAsset<T>(realPath);
+        }
+
+        private T GetMainAsset<T>(string fullPath) where T : Object
+        {
+            //basic find
+            Object loadedAsset = AssetDatabase.LoadMainAssetAtPath(fullPath);
+
+            if (loadedAsset != null)
+            {
+                if (loadedAsset is T cast)
+                {
+                    return cast;
+                }
+
+                LDtkDebug.LogError($"An asset was successfully loaded but was not the right type {fullPath}");
+                return null;
+            }
+
+            if (LOG)
+            {
+                LogFailIsAssetRelativeToAssetPathExists(fullPath);
+            }
+            return null;
+        }
+
+        private T GetAsset<T>(string fullPath) where T: Object
+        {
+            //basic find
+            Object loadedAsset = AssetDatabase.LoadAssetAtPath<T>(fullPath);
+
+            if (loadedAsset != null)
+            {
+                if (loadedAsset is T cast)
+                {
+                    return cast;
+                }
+
+                LDtkDebug.LogError($"An asset was successfully loaded but was not the right type {fullPath}");
+                return null;
+            }
+
+            if (LOG)
+            {
+                Debug.Log($"Nao foi possivel caregar {fullPath}");
+            }
+            return null;
+        }
+        
+
+        private string GetRelPathHD(TilesetDefinition definition, string relativeTo)
+        {
+            string relPath = relativeTo + "/" + GetRelPath(definition);
+
+            if (relPath != null)
+            {
+                if (relPath.EndsWith("SD.png"))
+                {
+                    var hd = relPath.Replace("SD.png", "HD.png");
+                    if (File.Exists(hd))
+                    {
+                        relPath = hd;
+                    }
+                }
+            }
+            
+            return relPath;
+        }
+        
+    }
+}

--- a/Assets/LDtkUnity/Editor/Utility/RelativeGetter/LDtkRelativeGetterTilesetTextureHD.cs.meta
+++ b/Assets/LDtkUnity/Editor/Utility/RelativeGetter/LDtkRelativeGetterTilesetTextureHD.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b454452314a1d8c44aa2d1288b4d1dad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
* Added new settings in LDtkJsonImporter.cs to allow load HD sprites
* Added new LDtkRelativeGetterTilesetTextureHD class to load the assets from alternative path and not from LDtk file
* Updated LDtkBuilderTileset to use HD version based on the new flag and added the pixelPerUnit logic to set the grid size