### PR TITLE
feat: `LDtkDefiniationObjectTileset` now references the relevant tileset artifact

### DIFF
--- a/Assets/LDtkUnity/Runtime/Data/Extensions/Definition/ScriptableObjects/LDtkDefinitionObjectTileset.cs
+++ b/Assets/LDtkUnity/Runtime/Data/Extensions/Definition/ScriptableObjects/LDtkDefinitionObjectTileset.cs
@@ -9,6 +9,9 @@ namespace LDtkUnity
         [field: Tooltip("Grid-based size")]
         [field: SerializeField] public Vector2Int CSize { get; private set; }
         
+        [field: Tooltip("Artifacts generated from this tileset that contain tiles and sprites.")]
+        [field: SerializeField] public LDtkArtifactAssetsTileset Artifacts { get; private set; }
+        
         [field: Tooltip("If this value is set, then it means that this atlas uses an internal LDtk atlas image instead of a loaded one.")]
         [field: SerializeField] public bool EmbedAtlas { get; private set; }
         
@@ -64,6 +67,7 @@ namespace LDtkUnity
         internal override void Populate(LDtkDefinitionObjectsCache cache, TilesetDefinition def)
         {
             CSize = def.UnityCSize;
+            Artifacts = cache.GetTilesetArtifacts(def.Uid);
             EmbedAtlas = def.EmbedAtlas != null;
             Identifier = def.Identifier;
             Padding = def.Padding;

--- a/Assets/LDtkUnity/Runtime/Data/Extensions/Definition/ScriptableObjects/LDtkDefinitionObjectsCache.cs
+++ b/Assets/LDtkUnity/Runtime/Data/Extensions/Definition/ScriptableObjects/LDtkDefinitionObjectsCache.cs
@@ -25,6 +25,7 @@ namespace LDtkUnity
         
         //key: tilesetuid, value: rectangle to sprite ref
         private Dictionary<int, Dictionary<Rect,Sprite>> _allSprites;
+        private Dictionary<int, LDtkArtifactAssetsTileset> _tilesetArtifacts;
         
         internal LDtkDefinitionObjectsCache(LDtkDebugInstance logger)
         {
@@ -69,9 +70,15 @@ namespace LDtkUnity
         
         private void InitializeTilesets(Dictionary<int, LDtkArtifactAssetsTileset> tilesets)
         {
-            _allSprites = new Dictionary<int, Dictionary<Rect,Sprite>>(tilesets.Count);
+            tilesets ??= new Dictionary<int, LDtkArtifactAssetsTileset>();
+            
+            _tilesetArtifacts = new Dictionary<int, LDtkArtifactAssetsTileset>(tilesets.Count);
+            _allSprites = new Dictionary<int, Dictionary<Rect, Sprite>>(tilesets.Count);
+            
             foreach (var pair in tilesets)
             {
+                _tilesetArtifacts[pair.Key] = pair.Value;
+                
                 Dictionary<Rect, Sprite> dict;
                 if (pair.Value != null)
                 {
@@ -83,6 +90,7 @@ namespace LDtkUnity
                 {
                     dict = new Dictionary<Rect, Sprite>();
                 }
+                
                 _allSprites.Add(pair.Key, dict);
             }
         }
@@ -212,7 +220,7 @@ namespace LDtkUnity
             _logger.LogError($"Failed to get a \"{typeof(T).Name}\" of uid {uid} due to a type mismatch with {obj.GetType().Name}");
             return null;
         }
-
+        
         /// <summary>
         /// Could return null sprite if the tile would only have clear pixels.
         /// <seealso cref="LDtkArtifactAssetsTileset.FindAdditionalSpriteForRect"/>
@@ -251,6 +259,16 @@ namespace LDtkUnity
             }
 
             return sprite;
+        }
+
+        internal LDtkArtifactAssetsTileset GetTilesetArtifacts(int uid)
+        {
+            if (_tilesetArtifacts != null && _tilesetArtifacts.TryGetValue(uid, out var artifacts))
+            {
+                return artifacts;
+            }
+
+            return null;
         }
         
         private void CacheDictToListViaProject()


### PR DESCRIPTION
This just adds a `Artifacts` property to the `LDtkDefiniationObjectTileset`. Currently there was no 'nice' way of retrieving a Tile sets relevant artifacts.

<img width="1217" height="605" alt="image" src="https://github.com/user-attachments/assets/a51adae9-d841-4b3f-8249-983056348ce4" />
