### PR TITLE
fix: point field of scaled objects

### DIFF
--- a/Assets/LDtkUnity/Editor/Builders/LDtkBuilderEntity.cs
+++ b/Assets/LDtkUnity/Editor/Builders/LDtkBuilderEntity.cs
@@ -13,6 +13,7 @@ namespace LDtkUnity.Editor
         private LDtkComponentEntity _entityComponent;
         private LDtkFields _fieldsComponent;
         private LDtkIid _iidComponent;
+        private LDtkFieldsFactory _fieldsFactory;
         
         public LDtkBuilderEntity(LDtkProjectImporter project, Level level, LDtkComponentLayer layerComponent, LDtkSortingOrder sortingOrder, LDtkLinearLevelVector linearVector, WorldLayout layout, LDtkAssetProcessorActionCache assetProcess, LDtkJsonImporter importer) 
             : base(project, level, layerComponent, sortingOrder, importer)
@@ -89,9 +90,9 @@ namespace LDtkUnity.Editor
         private void AddFieldData()
         {
             LDtkProfiler.BeginSample("SetEntityFieldsComponent");
-            LDtkFieldsFactory fieldsFactory = new LDtkFieldsFactory(_entityObj, _entity.FieldInstances, Project, Importer);
-            fieldsFactory.SetEntityFieldsComponent();
-            _fieldsComponent = fieldsFactory.FieldsComponent;
+            _fieldsFactory = new LDtkFieldsFactory(_entityObj, _entity.FieldInstances, Project, Importer);
+            _fieldsFactory.SetEntityFieldsComponent();
+            _fieldsComponent = _fieldsFactory.FieldsComponent;
             LDtkProfiler.EndSample();
             
             LDtkProfiler.BeginSample("InterfaceEvents");
@@ -128,6 +129,11 @@ namespace LDtkUnity.Editor
             newScale.x *= _entityComponent.ScaleFactor.x;
             newScale.y *= _entityComponent.ScaleFactor.y;
             _entityObj.transform.localScale = newScale;
+
+            if (_fieldsFactory != null)
+            {
+                _fieldsFactory.ApplyPointScale(_entityComponent.ScaleFactor);
+            }
         }
 
         private void PositionEntity()

--- a/Assets/LDtkUnity/Editor/ParsedField/LDtkFieldsFactory.cs
+++ b/Assets/LDtkUnity/Editor/ParsedField/LDtkFieldsFactory.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System.Collections.Generic;
+using UnityEngine;
 
 namespace LDtkUnity.Editor
 {
@@ -11,6 +12,7 @@ namespace LDtkUnity.Editor
         private readonly FieldInstance[] _fieldInstances;
         private readonly LDtkProjectImporter _project;
         private readonly LDtkJsonImporter _importer;
+        private readonly List<Transform> _pointTransforms = new List<Transform>();
         
         public LDtkFields FieldsComponent { get; private set; }
         
@@ -61,6 +63,8 @@ namespace LDtkUnity.Editor
                     {
                         LDtkFieldElement element = field._data[ii];
                         Transform newPoint = new GameObject($"{_fieldInstances[i].Identifier}_{ii}").transform;
+                        _pointTransforms.Add(newPoint);
+                        
                         element.SetPointLocalTransform(newPoint);
                         newPoint.SetParent(_instance.transform, true);
                     }
@@ -68,6 +72,17 @@ namespace LDtkUnity.Editor
                 LDtkProfiler.EndSample();
             }
             return fields;
+        }
+        
+        public void ApplyPointScale(Vector2 scale)
+        {
+            foreach (Transform point in _pointTransforms)
+            {
+                Vector3 local = point.localPosition;
+                local.x /= scale.x;
+                local.y /= scale.y;
+                point.localPosition = local;
+            }
         }
     }
 }


### PR DESCRIPTION
When a scalable entity as a point field, the Unity generated point will drift away due to the scaling. This PR fixes the problem by dividing all points by the entity scale. 
<img width="1056" height="855" alt="image" src="https://github.com/user-attachments/assets/1c5c6ea3-b7e5-44d6-a235-5f605526beda" />
I haven't tried with point array yet, though. It also adds a reference between the files, which may be a bad practice, but it solves the problem. 